### PR TITLE
Use cargo-binstall action

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: 'ubuntu-latest'
-            args: ''
-          - platform: 'windows-latest'
-            args: ''
+#          - platform: 'ubuntu-latest'
+#            args: ''
+#          - platform: 'windows-latest'
+#            args: ''
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest' # for Intel based macs.
@@ -35,7 +35,7 @@ jobs:
           targets: wasm32-unknown-unknown ${{ matrix.platform == 'macos-latest' && ',aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Install cargo-binstall
-        run: cargo install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.16.2
 
       - name: Install binaries
         run: cargo binstall tauri-cli@2 trunk wasm-bindgen-cli

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.16.2
 
       - name: Install binaries
-        run: cargo binstall tauri-cli@2 trunk wasm-bindgen-cli
+        run: cargo binstall -y tauri-cli@2 trunk wasm-bindgen-cli
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - platform: 'ubuntu-latest'
-#            args: ''
-#          - platform: 'windows-latest'
-#            args: ''
+          - platform: 'ubuntu-latest'
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest' # for Intel based macs.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install binaries
         run: cargo binstall -y tauri-cli@2 trunk wasm-bindgen-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
* Install `cargo-binstall` using action `cargo-bins/cargo-binstall` (why didn't I do this earlier)
* Export `GITHUB_TOKEN` to fix 403 Forbidden codes from github-api when using `cargo-binstall` https://github.com/cargo-bins/cargo-binstall/issues/2045